### PR TITLE
New parameter to kill traceroute syscall after n tentatives

### DIFF
--- a/lib/traceroute-lite.js
+++ b/lib/traceroute-lite.js
@@ -87,13 +87,16 @@ module.exports = Traceroute;
  * @param   {String} host An FQDN or IP address to trace.
  * @returns {Object} Returns the base traceroute class.
  */
-function Traceroute(host) {
+function Traceroute(host, maxNullHops) {
   if (!host || typeof host !== 'string')
     throw new Error('host must be a string');
 
   this.host = host;
   this.platform = Platform();
   this.profile = new Profile(this.platform);
+  if (maxNullHops !== undefined) {
+    this.maxNullHops = maxNullHops;
+  }
 
   this.reset();
 
@@ -114,6 +117,7 @@ Traceroute.prototype.reset = function () {
   this.stdout = '';
   this.stderr = '';
   this.hops = [];
+  this.maxNullHops = 5;
 }
 
 /**
@@ -127,6 +131,9 @@ Traceroute.prototype.start = function (callback) {
     stdout = this.stdout,
     stderr = this.stderr,
     hops = this.hops,
+    nullHops = 0,
+    maxNullHops = this.maxNullHops,
+    killed = false,
     parse = this.profile.parse,
     hopline = this.profile.hopline,
     emit = bind(this.emit, this);
@@ -145,7 +152,10 @@ Traceroute.prototype.start = function (callback) {
 
   // handle when the binary exits
   traceroute.on('exit', function (code) {
-    var error = (code !== 0) ? new Error(stderr.replace(/\n\r*/, ' ').trim()) : null;
+    var error = null;
+    if (!killed) {
+      error = (code !== 0) ? new Error(stderr.replace(/\n\r*/, ' ').trim()) : null;
+    }
 
     emit('done', error, hops);
 
@@ -155,6 +165,19 @@ Traceroute.prototype.start = function (callback) {
 
   this.on('hop', function (hop) {
     hops.push(hop);
+
+    if (hop.ip === null || hop.ms === null) {
+      // count every null hop received
+      nullHops++;
+    } else {
+      // reset nullHops counter when a valid hop is received
+      nullHops = 0;
+    }
+    // send a sigint to kill the traceroute process when it reach $maxNullHops hops in a row
+    if (maxNullHops && nullHops >= maxNullHops) {
+      traceroute.kill('SIGKILL');
+      killed = true;
+    }
   });
 
   /**


### PR DESCRIPTION
Hi!
I added a new parameter that permits to kill traceroute syscall after n null hops in a row.
With this fix, no traceroute syscall will last forever in processes queue.
